### PR TITLE
Fixes #87 - Make hashtags hyperlinks in HTML view

### DIFF
--- a/modules/hashtag/hashtag.go
+++ b/modules/hashtag/hashtag.go
@@ -1,0 +1,24 @@
+// Copyright 2016 The Gogs Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package hashtag
+
+import (
+	"regexp"
+	"strings"
+	"code.gitea.io/gitea/modules/setting"
+	"code.gitea.io/gitea/models"
+)
+
+func ConvertHashtagsToLinks(repo *models.Repository, html []byte) []byte {
+	repoName := repo.LowerName
+	indexOfUbn := strings.Index(repoName, "-ubn-")
+	if indexOfUbn > 0 {
+		ubnRepo := repoName[0:indexOfUbn+4]
+		hashtagsUrl := setting.AppSubUrl + "/" + repo.Owner.LowerName + "/" + ubnRepo + "/hashtags"
+		re, _ := regexp.Compile(`(^|\n|<p>)#([A-Za-uw-z0-9_-][\w-]+|v\d+[A-Za-z_-][\w-]*|v[A-Za-z_-][^\w-]*)`)
+		html = re.ReplaceAll(html, []byte("$1<a href=\"" + hashtagsUrl +"/$2\">#$2</a>$3"))
+	}
+	return html
+}

--- a/modules/hashtag/hashtag_test.go
+++ b/modules/hashtag/hashtag_test.go
@@ -1,0 +1,96 @@
+package hashtag_test
+
+import (
+	"testing"
+
+	. "code.gitea.io/gitea/modules/hashtag"
+	"code.gitea.io/gitea/modules/setting"
+	. "github.com/smartystreets/goconvey/convey"
+	"code.gitea.io/gitea/models"
+	"code.gitea.io/gitea/modules/markdown"
+)
+
+func TestHashtag(t *testing.T) {
+	var (
+		user = &models.User{
+			ID: 1,
+			LowerName: "joesmith",
+		}
+	)
+	setting.AppSubUrl = "http://example.com"
+
+	Convey("Rendering markdown with hashtags of a <lang>-ubn-<book> repo", t, func() {
+		var (
+			repo = &models.Repository{
+				ID: 1,
+				LowerName: "en-ubn-act",
+				Owner: user,
+			}
+		)
+
+		Convey("Rendering a single hashtag", func() {
+			So(string(ConvertHashtagsToLinks(repo, []byte(`#testtag`))), ShouldEqual, `<a href="http://example.com/joesmith/en-ubn/hashtags/testtag">#testtag</a>`)
+		})
+
+		Convey("Rendering markdown content into html with linked hashtag", func() {
+			markdown_content := []byte(`# Acts 1
+#author-luke
+
+This is some text saying where a hashtag in this line such as #test should not be rendered, but the
+following should be rendered as links except for #v12 which should not be a link:
+#v12
+#kingdomofgod
+#da-god
+`)
+			html_content := markdown.Render(markdown_content, "content/01.md", repo.ComposeMetas())
+			converted_hashtags := ConvertHashtagsToLinks(repo, html_content)
+			So(string(converted_hashtags), ShouldEqual, `<h1>Acts 1</h1>
+
+<p><a href="http://example.com/joesmith/en-ubn/hashtags/author-luke">#author-luke</a></p>
+
+<p>This is some text saying where a hashtag in this line such as #test should not be rendered, but the
+following should be rendered as links except for #v12 which should not be a link:
+#v12
+<a href="http://example.com/joesmith/en-ubn/hashtags/kingdomofgod">#kingdomofgod</a>
+<a href="http://example.com/joesmith/en-ubn/hashtags/da-god">#da-god</a></p>
+`)
+		})
+	})
+
+	Convey("Rendering markdown of a NON <lang>-ubn-<book> repo", t, func() {
+		var (
+			repo = &models.Repository{
+				ID: 1,
+				LowerName: "en-act",
+				Owner: user,
+			}
+		)
+
+		Convey("Should not render a single hashtag", func() {
+			So(string(ConvertHashtagsToLinks(repo, []byte(`#testtag`))), ShouldEqual, `#testtag`)
+		})
+
+		Convey("Should not render any hashtags of a markdown file", func() {
+			markdown_content := []byte(`<h1>Acts 1</h1>
+
+<p>#author-luke</p>
+
+<p>This is some text where no hashtags should be linked since this is not a ubn repo.
+#v12
+#kingdomofgod
+#da-god</p>
+`)
+			html_content := markdown.Render(markdown_content, "content/01.md", repo.ComposeMetas())
+			converted_hashtags := ConvertHashtagsToLinks(repo, html_content)
+			So(string(converted_hashtags), ShouldEqual, `<h1>Acts 1</h1>
+
+<p>#author-luke</p>
+
+<p>This is some text where no hashtags should be linked since this is not a ubn repo.
+#v12
+#kingdomofgod
+#da-god</p>
+`)
+		})
+	})
+}

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -23,6 +23,7 @@ import (
 	"code.gitea.io/gitea/modules/template/highlight"
 	"github.com/Unknwon/paginater"
 	"code.gitea.io/gitea/modules/yaml"
+	"code.gitea.io/gitea/modules/hashtag"
 )
 
 const (
@@ -88,6 +89,7 @@ func renderDirectory(ctx *context.Context, treeLink string) {
 			case markdown.IsMarkdownFile(readmeFile.Name()):
 				ctx.Data["IsMarkdown"] = true
 				buf = markdown.Render(buf, treeLink, ctx.Repo.Repository.ComposeMetas())
+				buf = hashtag.ConvertHashtagsToLinks(ctx.Repo.Repository, buf)
 			default:
 				// FIXME This is the only way to show non-markdown files
 				// instead of a broken "View Raw" link
@@ -167,6 +169,7 @@ func renderFile(ctx *context.Context, entry *git.TreeEntry, treeLink, rawLink st
 		if readmeExist && isMarkdown {
 			yamlHtml := yaml.RenderMarkdownYaml(buf)
 			markdownBody := markdown.Render(yaml.StripYamlFromText(buf), path.Dir(treeLink), ctx.Repo.Repository.ComposeMetas())
+			markdownBody = hashtag.ConvertHashtagsToLinks(ctx.Repo.Repository, markdownBody)
 			ctx.Data["FileContent"] = string(append(yamlHtml, markdownBody...))
 		} else if isYaml {
 			ctx.Data["FileContent"] = string(yaml.RenderYaml(buf))


### PR DESCRIPTION
Closes Issue #87 

To test, make a .md file like this:
```
asdfasd asdfasdfasd fasd f asdfas dfasdf 
#av111 
#bv2aab 
#v11 
#v2ab 
#v112

#asdfasdf
```

In the above, #v11 and #v112 should NOT become links but others should.