### PR TITLE
Fixes #80: add Google Analytics to templates

### DIFF
--- a/modules/setting/setting.go
+++ b/modules/setting/setting.go
@@ -261,6 +261,9 @@ var (
 	RunUser      string
 	IsWindows    bool
 	HasRobotsTxt bool
+	Google struct {
+		GATrackingID   string
+	}
 )
 
 // DateLang transforms standard language locale name to corresponding value in datetime plugin.
@@ -592,6 +595,7 @@ please consider changing to GITEA_CUSTOM`)
 	ShowFooterBranding = Cfg.Section("other").Key("SHOW_FOOTER_BRANDING").MustBool()
 	ShowFooterVersion = Cfg.Section("other").Key("SHOW_FOOTER_VERSION").MustBool()
 	ShowFooterTemplateLoadTime = Cfg.Section("other").Key("SHOW_FOOTER_TEMPLATE_LOAD_TIME").MustBool()
+	Google.GATrackingID = Cfg.Section("other").Key("GA_TRACKING_ID").String()
 
 	HasRobotsTxt = com.IsFile(path.Join(CustomPath, "robots.txt"))
 }

--- a/modules/template/template.go
+++ b/modules/template/template.go
@@ -116,6 +116,9 @@ func NewFuncMap() []template.FuncMap {
 			}
 			return "tab-size-8"
 		},
+		"GATrackingID": func() string {
+			return setting.Google.GATrackingID
+		},
 	}}
 }
 


### PR DESCRIPTION
To test:

Checkout the latest gogs-custom into your custom directory

In your custom/conf/app.ini add these lines:

```
[other]
GA_TRACKING_ID = UA-1111111-2
````

Run `gitea web`

You should now, in the source of a page of Gogs see the GA script tags at the very bottom with UA-111111-2 in the `ga('create', 'UA-1111111-2', 'auto');`.