### PR TITLE
Search users by email for admins

### DIFF
--- a/routers/admin/users.go
+++ b/routers/admin/users.go
@@ -31,12 +31,13 @@ func Users(ctx *context.Context) {
 	ctx.Data["PageIsAdminUsers"] = true
 
 	routers.RenderUserSearch(ctx, &routers.UserSearchOptions{
-		Type:     models.UserTypeIndividual,
-		Counter:  models.CountUsers,
-		Ranger:   models.Users,
-		PageSize: setting.UI.Admin.UserPagingNum,
-		OrderBy:  "id ASC",
-		TplName:  tplUsers,
+		Type:          models.UserTypeIndividual,
+		Counter:       models.CountUsers,
+		Ranger:        models.Users,
+		PageSize:      setting.UI.Admin.UserPagingNum,
+		OrderBy:       "id ASC",
+		TplName:       tplUsers,
+		SearchByEmail: true,
 	})
 }
 

--- a/routers/home.go
+++ b/routers/home.go
@@ -138,12 +138,13 @@ func ExploreRepos(ctx *context.Context) {
 
 // UserSearchOptions options when render search user page
 type UserSearchOptions struct {
-	Type     models.UserType
-	Counter  func() int64
-	Ranger   func(int, int) ([]*models.User, error)
-	PageSize int
-	OrderBy  string
-	TplName  base.TplName
+	Type          models.UserType
+	Counter       func() int64
+	Ranger        func(int, int) ([]*models.User, error)
+	PageSize      int
+	OrderBy       string
+	TplName       base.TplName
+	SearchByEmail bool // search by email as well as username/fullname
 }
 
 // RenderUserSearch render user search page
@@ -170,11 +171,12 @@ func RenderUserSearch(ctx *context.Context, opts *UserSearchOptions) {
 	} else {
 		if isKeywordValid(keyword) {
 			users, count, err = models.SearchUserByName(&models.SearchUserOptions{
-				Keyword:  keyword,
-				Type:     opts.Type,
-				OrderBy:  opts.OrderBy,
-				Page:     page,
-				PageSize: opts.PageSize,
+				Keyword:       keyword,
+				Type:          opts.Type,
+				OrderBy:       opts.OrderBy,
+				Page:          page,
+				PageSize:      opts.PageSize,
+				SearchByEmail: opts.SearchByEmail,
 			})
 			if err != nil {
 				ctx.Handle(500, "SearchUserByName", err)


### PR DESCRIPTION
Closes https://github.com/unfoldingWord-dev/gogs/issues/125.

Ideally, we would perform this search using an indexer, instead of an inefficient `LIKE %..%` SQL query, but this should at least work as a stopgap.