### PR TITLE
Issue 401, door43.org: Update copyright date

### DIFF
--- a/modules/templates/helper.go
+++ b/modules/templates/helper.go
@@ -133,6 +133,9 @@ func NewFuncMap() []template.FuncMap {
 			}
 			return path
 		},
+		"ThisYear": func() string {
+			return time.Now().Format("2006")
+		},
 	}}
 }
 

--- a/templates/base/footer.tmpl
+++ b/templates/base/footer.tmpl
@@ -7,7 +7,7 @@
 	<footer>
 		<div class="ui container">
 			<div class="ui left">
-				© 2016 Door43 - <span class="license">Except where otherwise noted, content on Door43 is licensed under a <bdi><a href="/Door43/en-legal/wiki/Copyrights-%26-Licensing" target="_blank">Creative Commons Attribution-ShareAlike 4.0 International License</a></bdi></span>
+				© {{ ThisYear }} Door43 - <span class="license">Except where otherwise noted, content on Door43 is licensed under a <bdi><a href="/Door43/en-legal/wiki/Copyrights-%26-Licensing" target="_blank">Creative Commons Attribution-ShareAlike 4.0 International License</a></bdi></span>
 			</div>
 			<div class="ui right links">
 				{{if (or .ShowFooterVersion .PageIsAdmin)}}{{.i18n.Tr "version"}}: {{AppVer}} {{.i18n.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong> {{.i18n.Tr "template"}}: <strong>{{call .TmplLoadTimes}}</strong>{{end}}


### PR DESCRIPTION
Make the copyright date always the current year, rather than a hard-coded value.

Partially implements https://github.com/unfoldingWord-dev/door43.org/issues/401