### PR TITLE
Display as text if YAML parse fails

### DIFF
--- a/modules/yaml/yaml.go
+++ b/modules/yaml/yaml.go
@@ -100,29 +100,21 @@ func renderVerticalHtmlTable(m []yaml.MapSlice) string {
 	return table
 }
 
-func RenderYaml(data []byte) []byte {
+func RenderYaml(data []byte) ([]byte, error) {
 	mss := []yaml.MapSlice{}
 
 	if len(data) < 1 {
-		return data
-	}
-
-	lines := strings.Split(string(data), "\r\n")
-	if len(lines) == 1 {
-		lines = strings.Split(string(data), "\n")
-	}
-	if len(lines) < 1 {
-		return data
+		return data, nil
 	}
 
 	if err := yaml.Unmarshal(data, &mss); err != nil {
 		ms := yaml.MapSlice{}
 		if err := yaml.Unmarshal(data, &ms); err != nil {
-			return data
+			return nil, err
 		}
-		return []byte(renderHorizontalHtmlTable(ms))
-	}  else {
-		return []byte(renderVerticalHtmlTable(mss))
+		return []byte(renderHorizontalHtmlTable(ms)), nil
+	} else {
+		return []byte(renderVerticalHtmlTable(mss)), nil
 	}
 }
 
@@ -183,14 +175,10 @@ func StripYamlFromText(data []byte) []byte {
 	return []byte(body)
 }
 
-func Render(rawBytes []byte) []byte {
-	result := RenderYaml(rawBytes)
-	result = Sanitizer.SanitizeBytes(result)
-	return result
+func Render(rawBytes []byte) ([]byte, error) {
+	result, err := RenderYaml(rawBytes)
+	if err != nil {
+		return nil, err
+	}
+	return Sanitizer.SanitizeBytes(result), nil
 }
-
-// Renders the YAML and text as a string
-func RenderString(rawBytes []byte) string {
-	return string(Render(rawBytes))
-}
-

--- a/modules/yaml/yaml_test.go
+++ b/modules/yaml/yaml_test.go
@@ -1,0 +1,30 @@
+// Copyright 2017 The Gitea Authors. All rights reserved.
+// Use of this source code is governed by a MIT-style
+// license that can be found in the LICENSE file.
+
+package yaml
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRenderYaml(t *testing.T) {
+	// LF line endings
+	contents := "a: 1\nb: 2\n"
+	rendered, err := RenderYaml([]byte(contents))
+	assert.NoError(t, err)
+	assert.True(t, strings.HasSuffix(string(rendered), "</table>"))
+
+	// CRLF line endings
+	contents = "a: 1\r\nb: 2\r\n"
+	_, err = RenderYaml([]byte(contents))
+	assert.NoError(t, err)
+	assert.True(t, strings.HasSuffix(string(rendered), "</table>"))
+
+	contents = "misformatted&"
+	_, err = RenderYaml([]byte(contents))
+	assert.Error(t, err)
+}

--- a/routers/api/v1/misc/yaml.go
+++ b/routers/api/v1/misc/yaml.go
@@ -22,7 +22,10 @@ func Yaml(ctx *context.APIContext, form api.YamlOption) {
 		ctx.Write([]byte(""))
 		return
 	}
-
-	ctx.Write(yaml.Render([]byte(form.Text)))
+	if rendered, err := yaml.Render([]byte(form.Text)); err != nil {
+		ctx.Error(400, "Unable to parse YAML", err)
+	} else {
+		ctx.Write(rendered)
+	}
 }
 


### PR DESCRIPTION
Display a YAML file that fails to parse as a normal text file. Also displays the parsing error message.

Addresses #139.
