### PR TITLE
Fix CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,14 @@ env:
   TAGS: cert sqlite pam miniwinsvc
 
 before_install:
-  - sudo apt-get update -qq
   - sudo apt-get install -y libpam-dev
 
 install:
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls
-  
+  - go get github.com/wadey/gocovmerge
+
 script:
-  - go get ./...
   - make clean
   - make vet
 
@@ -28,4 +27,4 @@ script:
   - make build
 
 after_success:
-  - bash <(curl -s https://codecov.io/bash)
+  - ./test-coverage.sh

--- a/Makefile
+++ b/Makefile
@@ -68,8 +68,7 @@ lint:
 
 .PHONY: test
 test:
-#	for PKG in $(PACKAGES); do go test -cover -coverprofile $$GOPATH/src/$$PKG/coverage.out $$PKG || exit 1; done;
-	./test-coverage.sh
+	go test -cover $(PACKAGES)
 
 .PHONY: test-mysql
 test-mysql:

--- a/modules/hashtag/hashtag_test.go
+++ b/modules/hashtag/hashtag_test.go
@@ -3,94 +3,85 @@ package hashtag_test
 import (
 	"testing"
 
-	. "code.gitea.io/gitea/modules/hashtag"
-	"code.gitea.io/gitea/modules/setting"
-	. "github.com/smartystreets/goconvey/convey"
 	"code.gitea.io/gitea/models"
+	. "code.gitea.io/gitea/modules/hashtag"
 	"code.gitea.io/gitea/modules/markdown"
+	"code.gitea.io/gitea/modules/setting"
+
+	"github.com/stretchr/testify/assert"
 )
 
-func TestHashtag(t *testing.T) {
-	var (
-		user = &models.User{
-			ID: 1,
-			LowerName: "joesmith",
-		}
-	)
+func TestHashtagUBN(t *testing.T) {
+	user := &models.User{ID: 1, LowerName: "username"}
 	setting.AppSubURL = "http://example.com"
 
-	Convey("Rendering markdown with hashtags of a <lang>-ubn-<book> repo", t, func() {
-		var (
-			repo = &models.Repository{
-				ID: 1,
-				LowerName: "en-ubn-act",
-				Owner: user,
-			}
-		)
+	repo := &models.Repository{
+		ID:        1,
+		LowerName: "en-ubn-act",
+		Owner:     user,
+	}
 
-		Convey("Rendering a single hashtag", func() {
-			So(string(ConvertHashtagsToLinks(repo, []byte(`#testtag`))), ShouldEqual, `<a href="http://example.com/joesmith/en-ubn/hashtags/testtag">#testtag</a>`)
-		})
+	assert.Equal(t,
+		`<a href="http://example.com/username/en-ubn/hashtags/testtag">#testtag</a>`,
+		string(ConvertHashtagsToLinks(repo, []byte(`#testtag`))))
 
-		Convey("Rendering markdown content into html with linked hashtag", func() {
-			markdown_content := []byte(`# Acts 1
+	markdownContent := []byte(
+		`# Acts 1
 #author-luke
 
-This is some text saying where a hashtag in this line such as #test should not be rendered, but the
+A hashtag in this line such as #test should not be rendered, but the
 following should be rendered as links except for #v12 which should not be a link:
 #v12
 #kingdomofgod
 #da-god
 `)
-			html_content := markdown.Render(markdown_content, "content/01.md", repo.ComposeMetas())
-			converted_hashtags := ConvertHashtagsToLinks(repo, html_content)
-			So(string(converted_hashtags), ShouldEqual, `<h1>Acts 1</h1>
+	htmlContent := markdown.Render(markdownContent, "content/01.md", nil)
+	convertedHashtags := ConvertHashtagsToLinks(repo, htmlContent)
+	assert.Equal(t,
+		`<h1>Acts 1</h1>
 
-<p><a href="http://example.com/joesmith/en-ubn/hashtags/author-luke">#author-luke</a></p>
+<p><a href="http://example.com/username/en-ubn/hashtags/author-luke">#author-luke</a></p>
 
-<p>This is some text saying where a hashtag in this line such as #test should not be rendered, but the
+<p>A hashtag in this line such as #test should not be rendered, but the
 following should be rendered as links except for #v12 which should not be a link:
 #v12
-<a href="http://example.com/joesmith/en-ubn/hashtags/kingdomofgod">#kingdomofgod</a>
-<a href="http://example.com/joesmith/en-ubn/hashtags/da-god">#da-god</a></p>
-`)
-		})
-	})
+<a href="http://example.com/username/en-ubn/hashtags/kingdomofgod">#kingdomofgod</a>
+<a href="http://example.com/username/en-ubn/hashtags/da-god">#da-god</a></p>
+`, string(convertedHashtags))
+}
 
-	Convey("Rendering markdown of a NON <lang>-ubn-<book> repo", t, func() {
-		var (
-			repo = &models.Repository{
-				ID: 1,
-				LowerName: "en-act",
-				Owner: user,
-			}
-		)
+func TestHashtagNonUBN(t *testing.T) {
+	user := &models.User{ID: 1, LowerName: "username"}
+	setting.AppSubURL = "http://example.com"
 
-		Convey("Should not render a single hashtag", func() {
-			So(string(ConvertHashtagsToLinks(repo, []byte(`#testtag`))), ShouldEqual, `#testtag`)
-		})
+	repo := &models.Repository{
+		ID:        1,
+		LowerName: "en-act",
+		Owner:     user,
+	}
 
-		Convey("Should not render any hashtags of a markdown file", func() {
-			markdown_content := []byte(`<h1>Acts 1</h1>
+	assert.Equal(t, `#testtag`, string(ConvertHashtagsToLinks(repo, []byte(`#testtag`))))
+
+	markdownContent := []byte(
+		`<h1>Acts 1</h1>
 
 <p>#author-luke</p>
 
-<p>This is some text where no hashtags should be linked since this is not a ubn repo.
+<p>No hashtags should be linked since this is not a ubn repo.
 #v12
 #kingdomofgod
 #da-god</p>
 `)
-			html_content := markdown.Render(markdown_content, "content/01.md", repo.ComposeMetas())
-			converted_hashtags := ConvertHashtagsToLinks(repo, html_content)
-			So(string(converted_hashtags), ShouldEqual, `<h1>Acts 1</h1>
+	htmlContent := markdown.Render(markdownContent, "content/01.md", nil)
+	convertedHashtags := ConvertHashtagsToLinks(repo, htmlContent)
+	assert.Equal(t,
+		`<h1>Acts 1</h1>
 
 <p>#author-luke</p>
 
-<p>This is some text where no hashtags should be linked since this is not a ubn repo.
+<p>No hashtags should be linked since this is not a ubn repo.
 #v12
 #kingdomofgod
 #da-god</p>
-`)
-		})
-	})
+`, string(convertedHashtags))
 }

--- a/modules/scrub/scrub_test.go
+++ b/modules/scrub/scrub_test.go
@@ -1,27 +1,28 @@
 package scrub_test
 
 import (
-	"testing"
-	"os"
-	"io"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
 	"path"
 	"path/filepath"
-	"io/ioutil"
-
-	. "github.com/smartystreets/goconvey/convey"
-	"code.gitea.io/gitea/modules/scrub"
-	"code.gitea.io/git"
+	"testing"
 	"time"
+
+	"code.gitea.io/git"
+	"code.gitea.io/gitea/modules/scrub"
+
+	"github.com/stretchr/testify/assert"
 )
 
 // The repos to be tested and the "success" result that should be expected
 var TESTING_REPOS = map[string]bool{
-	"all_json_files": true,
-	"bad_json_file": false,
+	"all_json_files":            true,
+	"bad_json_file":             false,
 	"multiple_sensitive_fields": true,
-	"no_json_files": false,
-	"no_sensitive_data": true,
+	"no_json_files":             false,
+	"no_sensitive_data":         true,
 }
 
 func TestScrubJsonFiles(t *testing.T) {
@@ -36,20 +37,18 @@ func TestScrubJsonFiles(t *testing.T) {
 		git.AddChanges(repoDir, true)
 		git.CommitChanges(repoDir, git.CommitChangesOptions{
 			Committer: &git.Signature{
-				Name: "John Smith",
+				Name:  "John Smith",
 				Email: "john@smith.com",
-				When: time.Now(),
+				When:  time.Now(),
 			},
 			Author: &git.Signature{
-				Name: "John Smith",
+				Name:  "John Smith",
 				Email: "john@smith.com",
-				When: time.Now(),
+				When:  time.Now(),
 			},
 			Message: "Initial Commit",
 		})
-		Convey(fmt.Sprintf("The repo %s should return %v", repoName, expectedResult), t, func() {
-			So(scrub.ScrubJsonFiles(repoDir), ShouldEqual, expectedResult)
-		})
+		assert.Equal(t, expectedResult, scrub.ScrubJsonFiles(repoDir))
 	}
 }
 

--- a/test-coverage.sh
+++ b/test-coverage.sh
@@ -1,28 +1,11 @@
-#!/bin/bash
+#! /usr/bin/env bash
 
-echo "mode: set" > acc.out
-for Dir in $(find ./* -maxdepth 10 -type d ); 
+set -e
+set -o verbose
+
+for PKG in $(go list ./... | grep -v /vendor/);
 do
-	if ls $Dir/*.go &> /dev/null;
-	then
-		returnval=`go test -coverprofile=profile.out $Dir`
-		echo ${returnval}
-		if [[ ${returnval} != *FAIL* ]]
-		then
-    		if [ -f profile.out ]
-    		then
-        		cat profile.out | grep -v "mode: set" >> acc.out 
-    		fi
-    	else
-    		exit 1
-    	fi	
-    fi
-done
-if [ -n "$COVERALLS" ]
-then
-	goveralls -coverprofile=acc.out $COVERALLS
-fi	
-
-rm -rf ./profile.out
-rm -rf ./acc.out
-
+  go test -cover -coverprofile $GOPATH/src/$PKG/coverage.out $PKG || exit 1;
+done;
+gocovmerge $(find -type f -name "coverage.out") > coverage.out;
+goveralls -coverprofile=coverage.out;


### PR DESCRIPTION
Fixes the following:
* Ensures that failing tests cause the build to fail. This was not previously the case (e.g. https://travis-ci.org/unfoldingWord-dev/gogs/jobs/204700925)
* Fixes tests (`modules/scrub/scrub_test.go` and `modules/hashtag/hashtag_test.go`) that used removed dependencies; the fact that these tests had missing dependencies was never caught because failing tests would not break the build
* Don't test the dependencies in `vendor/` (#148)
* Runs tests without coverage first, then only with coverage if they passed without coverage. It's much faster to run tests without coverage (since you can test multiple packages at once, which saves you from repeated recompiling). This will cause failing builds to fail faster, which will hopefully expedite development workflows.
* Fix coverage calculations; we previously concatenate these various `coverage.out` report into a single report, but this caused problems if multiple packages had coverage in the same location. I found the `gocovmerge` tool which can merge coverage report intelligently.