### PR TITLE
Fixes #173 - Restores the HashTag code in Issue comments

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,8 @@ language: go
 go_import_path: code.gitea.io/gitea
 
 go:
-  - 1.6
   - 1.7
+  - 1.8
 
 env:
   TAGS: cert sqlite pam miniwinsvc

--- a/models/issue.go
+++ b/models/issue.go
@@ -282,6 +282,11 @@ func (issue *Issue) APIFormat() *api.Issue {
 	return apiIssue
 }
 
+// HashTag returns unique hash tag for issue.
+func (issue *Issue) HashTag() string {
+	return "issue-" + com.ToStr(issue.ID)
+}
+
 // IsPoster returns true if given user by ID is the poster.
 func (issue *Issue) IsPoster(uid int64) bool {
 	return issue.PosterID == uid

--- a/models/issue_comment.go
+++ b/models/issue_comment.go
@@ -198,6 +198,11 @@ func (c *Comment) APIFormat() *api.Comment {
 	}
 }
 
+// HashTag returns unique hash tag for comment.
+func (c *Comment) HashTag() string {
+	return "issuecomment-" + com.ToStr(c.ID)
+}
+
 // EventTag returns unique event hash tag for comment.
 func (c *Comment) EventTag() string {
 	return "event-" + com.ToStr(c.ID)

--- a/templates/repo/issue/view_content.tmpl
+++ b/templates/repo/issue/view_content.tmpl
@@ -17,7 +17,7 @@
 				</a>
 				<div class="content">
 					<div class="ui top attached header">
-						<span class="text grey"><a {{if gt .Issue.Poster.ID 0}}href="{{.Issue.Poster.HomeLink}}"{{end}}>{{.Issue.Poster.Name}}</a> {{.i18n.Tr "repo.issues.commented_at" $createdStr | Safe}}</span>
+						<span class="text grey"><a {{if gt .Issue.Poster.ID 0}}href="{{.Issue.Poster.HomeLink}}"{{end}}>{{.Issue.Poster.Name}}</a> {{.i18n.Tr "repo.issues.commented_at" .Issue.HashTag $createdStr | Safe}}</span>
 						<div class="ui right actions">
 							{{if .IsIssueOwner}}
 								<div class="item action">


### PR DESCRIPTION
Restores the HashTag code that was removed in https://github.com/unfoldingWord-dev/gogs/commit/5fa9875f8952855aea33678070c554cd616c98e8#diff-d5eea3b2c0d4c92d62e12b34eb8da2c0L285, https://github.com/unfoldingWord-dev/gogs/commit/5fa9875f8952855aea33678070c554cd616c98e8#diff-9dbad6d760dba020a994d9ecc3fd09dcL201 and https://github.com/unfoldingWord-dev/gogs/commit/5fa9875f8952855aea33678070c554cd616c98e8#diff-b931917724d3c6a76e48c835dc509284L20 since it actually didn't have to do with our HashTag code.

This makes it so https://aws.door43.org/Door43/en-uhg/issues/24 isn't broken, looking like this: http://test.door43.org:3000/richmahn/test2/issues/1 (test.door43.org is currently using this fork/branch)