### PR TITLE
Feature - Issue #123 - Updates email templates

### DIFF
--- a/templates/mail/issue/comment.tmpl
+++ b/templates/mail/issue/comment.tmpl
@@ -10,7 +10,7 @@
 	<p>
 		---
 		<br>
-		<a href="{{.Link}}">View it on Gitea</a>.
+		<a href="{{.Link}}">View it on Door43 Content Service</a>.
 	</p>
 </body>
 </html>

--- a/templates/mail/issue/mention.tmpl
+++ b/templates/mail/issue/mention.tmpl
@@ -11,7 +11,7 @@
 	<p>
 		---
 		<br>
-		<a href="{{.Link}}">View it on Gitea</a>.
+		<a href="{{.Link}}">View it on Door43 Content Service</a>.
 	</p>
 </body>
 </html>

--- a/templates/mail/notify/collaborator.tmpl
+++ b/templates/mail/notify/collaborator.tmpl
@@ -10,7 +10,7 @@
 	<p>
 		---
 		<br>
-		<a href="{{.Link}}">View it on Gitea</a>.
+		<a href="{{.Link}}">View it on Door43 Content Service</a>.
 	</p>
 </body>
 </html>


### PR DESCRIPTION
To make sure we have better Door43 branding, emails don't refer to our site as "Gitea".