### PR TITLE
Feature - Issue #170 - Update YAML Viewer

### DIFF
--- a/modules/yaml/yaml.go
+++ b/modules/yaml/yaml.go
@@ -42,6 +42,13 @@ func renderHorizontalHtmlTable(m yaml.MapSlice) string {
 
 		if value != nil && reflect.TypeOf(value).String() == "yaml.MapSlice" {
 			value = renderHorizontalHtmlTable(value.(yaml.MapSlice))
+		} else if value != nil && reflect.TypeOf(value).String() == "[]interface {}" {
+			value = value.([]interface{})
+			v := make([]yaml.MapSlice, len(value.([]interface{})))
+			for i, vs := range value.([]interface{}) {
+				v[i] = vs.(yaml.MapSlice)
+			}
+			value = renderVerticalHtmlTable(v)
 		}
 		tbody += fmt.Sprintf("<td>%v</td>", value)
 	}
@@ -90,6 +97,8 @@ func renderVerticalHtmlTable(m []yaml.MapSlice) string {
 			}
 			if key == "slug" {
 				value = fmt.Sprintf(`<a href="content/%v.md">%v</a>`, value, value)
+			} else if key == "link" {
+				value = fmt.Sprintf(`<a href="%v/01.md">%v</a>`, value, value)
 			}
 			table += fmt.Sprintf("<td>%v</td>", value)
 

--- a/modules/yaml/yaml.go
+++ b/modules/yaml/yaml.go
@@ -35,14 +35,16 @@ func renderHorizontalHtmlTable(m yaml.MapSlice) string {
 		key := mi.Key
 		value := mi.Value
 
-		if key != nil && reflect.TypeOf(key).String() == "yaml.MapSlice" {
+		switch reflect.TypeOf(key).String() {
+		case "yaml.MapSlice":
 			key = renderHorizontalHtmlTable(key.(yaml.MapSlice))
 		}
 		thead += fmt.Sprintf("<th>%v</th>", key)
 
-		if value != nil && reflect.TypeOf(value).String() == "yaml.MapSlice" {
+		switch reflect.TypeOf(value).String(){
+		case "yaml.MapSlice":
 			value = renderHorizontalHtmlTable(value.(yaml.MapSlice))
-		} else if value != nil && reflect.TypeOf(value).String() == "[]interface {}" {
+		case "[]interface {}":
 			value = value.([]interface{})
 			v := make([]yaml.MapSlice, len(value.([]interface{})))
 			for i, vs := range value.([]interface{}) {
@@ -72,9 +74,10 @@ func renderVerticalHtmlTable(m []yaml.MapSlice) string {
 			value := mi.Value
 
 			table += `<tr>`
-			if key != nil && reflect.TypeOf(key).String() == "yaml.MapSlice" {
+			switch reflect.TypeOf(key).String() {
+			case "yaml.MapSlice":
 				key = renderHorizontalHtmlTable(key.(yaml.MapSlice))
-			} else if key != nil && reflect.TypeOf(key).String() == "[]interface {}" {
+			case "[]interface {}":
 				var ks string
 				for _, ki := range key.([]interface{}) {
 					log.Info("KI: %v", ki)
@@ -85,9 +88,10 @@ func renderVerticalHtmlTable(m []yaml.MapSlice) string {
 			}
 			table += fmt.Sprintf("<td>%v</td>", key)
 
-			if value != nil && reflect.TypeOf(value).String() == "yaml.MapSlice" {
+			switch reflect.TypeOf(value).String() {
+			case "yaml.MapSlice":
 				value = renderHorizontalHtmlTable(value.(yaml.MapSlice))
-			} else if value != nil && reflect.TypeOf(value).String() == "[]interface {}" {
+			case "[]interface {}":
 				value = value.([]interface{})
 				v := make([]yaml.MapSlice, len(value.([]interface{})))
 				for i, vs := range value.([]interface{}) {
@@ -95,13 +99,14 @@ func renderVerticalHtmlTable(m []yaml.MapSlice) string {
 				}
 				value = renderVerticalHtmlTable(v)
 			}
-			if key == "slug" {
+
+			switch key {
+			case "slug":
 				value = fmt.Sprintf(`<a href="content/%v.md">%v</a>`, value, value)
-			} else if key == "link" {
+			case "link":
 				value = fmt.Sprintf(`<a href="%v/01.md">%v</a>`, value, value)
 			}
 			table += fmt.Sprintf("<td>%v</td>", value)
-
 			table += `</tr>`
 		}
 		table += "</table>"

--- a/modules/yaml/yaml.go
+++ b/modules/yaml/yaml.go
@@ -35,16 +35,16 @@ func renderHorizontalHtmlTable(m yaml.MapSlice) string {
 		key := mi.Key
 		value := mi.Value
 
-		switch reflect.TypeOf(key).String() {
-		case "yaml.MapSlice":
+		switch key.(type) {
+		case yaml.MapSlice:
 			key = renderHorizontalHtmlTable(key.(yaml.MapSlice))
 		}
 		thead += fmt.Sprintf("<th>%v</th>", key)
 
-		switch reflect.TypeOf(value).String(){
-		case "yaml.MapSlice":
+		switch value.(type) {
+		case yaml.MapSlice:
 			value = renderHorizontalHtmlTable(value.(yaml.MapSlice))
-		case "[]interface {}":
+		case []interface {}:
 			value = value.([]interface{})
 			v := make([]yaml.MapSlice, len(value.([]interface{})))
 			for i, vs := range value.([]interface{}) {
@@ -74,10 +74,10 @@ func renderVerticalHtmlTable(m []yaml.MapSlice) string {
 			value := mi.Value
 
 			table += `<tr>`
-			switch reflect.TypeOf(key).String() {
-			case "yaml.MapSlice":
+			switch key.(type) {
+			case yaml.MapSlice:
 				key = renderHorizontalHtmlTable(key.(yaml.MapSlice))
-			case "[]interface {}":
+			case []interface {}:
 				var ks string
 				for _, ki := range key.([]interface{}) {
 					log.Info("KI: %v", ki)
@@ -88,10 +88,10 @@ func renderVerticalHtmlTable(m []yaml.MapSlice) string {
 			}
 			table += fmt.Sprintf("<td>%v</td>", key)
 
-			switch reflect.TypeOf(value).String() {
-			case "yaml.MapSlice":
+			switch value.(type) {
+			case yaml.MapSlice:
 				value = renderHorizontalHtmlTable(value.(yaml.MapSlice))
-			case "[]interface {}":
+			case []interface {}:
 				value = value.([]interface{})
 				v := make([]yaml.MapSlice, len(value.([]interface{})))
 				for i, vs := range value.([]interface{}) {

--- a/routers/repo/view.go
+++ b/routers/repo/view.go
@@ -196,13 +196,13 @@ func renderFile(ctx *context.Context, entry *git.TreeEntry, treeLink, rawLink st
 
 		readmeExist := isSupportedMarkup || markup.IsReadmeFile(blob.Name())
 		ctx.Data["ReadmeExist"] = readmeExist
-		isYaml := yaml.IsYamlFile(blob.Name())
-		ctx.Data["IsYaml"] = isYaml
+		isTocYaml := blob.Name() == "toc.yaml"
+		ctx.Data["IsTocYaml"] = isTocYaml
 		if readmeExist && isSupportedMarkup {
 			yamlHtml := yaml.RenderMarkdownYaml(buf)
 			markupBody := markup.Render(blob.Name(), yaml.StripYamlFromText(buf), path.Dir(treeLink), ctx.Repo.Repository.ComposeMetas())
 			ctx.Data["FileContent"] = string(append(yamlHtml, markupBody...))
-		} else if isYaml {
+		} else if isTocYaml {
 			rendered, err := yaml.RenderYaml(buf)
 			if err == nil {
 				ctx.Data["FileContent"] = string(rendered)

--- a/templates/repo/view_file.tmpl
+++ b/templates/repo/view_file.tmpl
@@ -36,12 +36,12 @@
 		{{end}}
 	</h4>
 	<div class="ui attached table segment">
-		<div class="file-view {{if .IsMarkdown}}markdown{{else if .IsYaml}}markdown yaml{{else if .IsTextFile}}code-view{{end}} has-emoji">
+		<div class="file-view {{if .IsMarkdown}}markdown{{else if .IsTocYaml}}markdown yaml{{else if .IsTextFile}}code-view{{end}} has-emoji">
 			{{if .IsMarkdown}}
 				<article class="markdown-body" itemprop="text">
 				{{if .FileContent}}{{.FileContent | Str2html}}{{end}}
 				</article>
-			{{else if .IsYaml}}
+			{{else if .IsTocYaml}}
 				<article class="markdown-body" itemprop="text">
 				{{if .FileContent}}{{.FileContent | Str2html}}{{end}}
 				</article>


### PR DESCRIPTION
Simply removes rendering ALL .yaml files as tables, and just does it for toc.yaml.

For example, http://test.door43.org:3000/richmahn/en_ta/src/master/checking/toc.yaml uses this update, showing a table with clickable "link"s, and a proper rendering of the array of arrays of maps.

Where as http://test.door43.org:3000/richmahn/en_ta/src/master/manifest.yaml shows the YAML using the default view, highlighting YAML syntax.

This also fixes how the new en_ta's toc.yaml is an array of arrays which broke the production view (https://git.door43.org/Door43/en_ta/src/master/checking/toc.yaml) showing the section data as an ugly string. 

It also links "link" to `<link>/01.md` where as before it mapped "slug" to `content/<link>.md` (old way: https://git.door43.org/Door43/en-ta-translate-vol1/src/master/toc.yaml)
