### PR TITLE
UI tweaks for 'See on Door43' button

### DIFF
--- a/public/css/index.css
+++ b/public/css/index.css
@@ -3111,16 +3111,11 @@ table[data-table-type="yaml-metadata"] {
 .ui.user.list .item .description a:hover {
   text-decoration: underline;
 }
-.no-padding-button {
-  display: inline-flex;
-  padding: 0px !important;
-  margin: 0 .25em 0 0;
-}
-.door43-logo {
-  height: 20px;
-  width: 20px;
-  margin-top: -12px;
-  margin-bottom: -8px;
+#door43-logo {
+  height: 20px !important;
+  width: 20px !important;
+  margin-top: -10px !important;
+  margin-bottom: -10px !important;
   vertical-align: middle;
   display: inline-block;
 }
@@ -3130,4 +3125,8 @@ table[data-table-type="yaml-metadata"] {
 }
 .empty-icon:before {
   content: "\200b";
+}
+.repo-button-separator {
+  display: inline-flex;
+  width: 5px;
 }

--- a/public/less/_unfoldingWord.less
+++ b/public/less/_unfoldingWord.less
@@ -1,23 +1,23 @@
 @door43-logo-size: 20px;
 
 #door43-logo {
-    height: @door43-logo-size !important;
-    width: @door43-logo-size !important;
-    margin-top: -0.5* @door43-logo-size !important;
-    margin-bottom: -0.5 * @door43-logo-size !important;
-    vertical-align: middle;
-    display: inline-block;
+	height: @door43-logo-size !important;
+	width: @door43-logo-size !important;
+	margin-top: -0.5* @door43-logo-size !important;
+	margin-bottom: -0.5 * @door43-logo-size !important;
+	vertical-align: middle;
+	display: inline-block;
 }
 
 .empty-icon {
-    width: 0px !important;
-    margin: 0 0 0 0 !important;
-    &:before {
-        content: "\200b"; // zero-width space
-    }
+	width: 0px !important;
+	margin: 0 0 0 0 !important;
+	&:before {
+		content: "\200b"; // zero-width space
+	}
 }
 
 .repo-button-separator {
-    display: inline-flex;
-    width: 5px;
+	display: inline-flex;
+	width: 5px;
 }

--- a/public/less/_unfoldingWord.less
+++ b/public/less/_unfoldingWord.less
@@ -1,15 +1,10 @@
 @door43-logo-size: 20px;
 
-.no-padding-button {
-    display: inline-flex;
-    padding: 0px !important;
-}
-
-.door43-logo {
-    height: @door43-logo-size;
-    width: @door43-logo-size;
-    margin-top: -0.6 * @door43-logo-size;
-    margin-bottom: -0.4 * @door43-logo-size;
+#door43-logo {
+    height: @door43-logo-size !important;
+    width: @door43-logo-size !important;
+    margin-top: -0.5* @door43-logo-size !important;
+    margin-bottom: -0.5 * @door43-logo-size !important;
     vertical-align: middle;
     display: inline-block;
 }
@@ -20,4 +15,9 @@
     &:before {
         content: "\200b"; // zero-width space
     }
+}
+
+.repo-button-separator {
+    display: inline-flex;
+    width: 5px;
 }

--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -14,13 +14,16 @@
 					</div>
 
 					<div class="ui right">
-						<div class="no-padding-button" tabindex="0">
+						<div class="ui compact labeled button" id="see-on-door43-button" tabindex="0">
 							<a class="ui compact button" target="_blank" href="https://live.door43.org/u/{{.Owner.Name}}/{{.Name}}/">
 								<!-- empty icon ensures that this button is same size as Watch/Star/Fork buttons -->
-								<i class="icon empty-icon"></i>
-								<img class="door43-logo" src="/img/door43.png"/>
-								<span>{{$.i18n.Tr "repo.see_on_door43"}}</span>
+								<i class="icon empty-icon"></i><span>{{$.i18n.Tr "repo.see_on_door43"}}</span>
 							</a>
+							<a class="ui basic left pointing label" href="https://live.door43.org/u/{{.Owner.Name}}/{{.Name}}/">
+								&#xfeff;<img id="door43-logo" src="/img/door43.png"/>
+							</a>
+						</div>
+						<div class="repo-button-separator">
 						</div>
 						<div class="ui compact labeled button" tabindex="0">
 							<a class="ui compact button" href="{{$.RepoLink}}/action/{{if $.IsWatchingRepo}}un{{end}}watch?redirect_to={{$.Link}}">


### PR DESCRIPTION
Even with https://github.com/unfoldingWord-dev/gogs/commit/d2d0de417140a43ecbc110d466edde3120057692, the 'See on Door43' button isn't quite consistent with the Watch/Fork/Star buttons (it's about 1px shorter). The only way I could find to ensure that the buttons have the same height (without resorting to a ridiculous hack) was to add a label to the 'See on Door43' button.

Other tweaks:
- I added a little separation between the 'See on Door43' button and the Watch/Fork/Star buttons.
- I made the 'See on Door43' label pointed, to distinguish it from the Watch/Forks/Star labels which serve as counts.


Before:
![image](https://user-images.githubusercontent.com/8990880/27651316-e652eb72-5c05-11e7-8079-12b14ac29d5d.png)


After:
![image](https://user-images.githubusercontent.com/8990880/27651219-8a49582a-5c05-11e7-85d7-ff9257fb23d0.png)
