### PR TITLE
update_live_site_link_to_bare_door43.org

### DIFF
--- a/templates/repo/header.tmpl
+++ b/templates/repo/header.tmpl
@@ -15,11 +15,11 @@
 
 					<div class="ui right">
 						<div class="ui compact labeled button" id="see-on-door43-button" tabindex="0">
-							<a class="ui compact button" target="_blank" href="https://live.door43.org/u/{{.Owner.Name}}/{{.Name}}/">
+							<a class="ui compact button" target="_blank" href="https://door43.org/u/{{.Owner.Name}}/{{.Name}}/">
 								<!-- empty icon ensures that this button is same size as Watch/Star/Fork buttons -->
 								<i class="icon empty-icon"></i><span>{{$.i18n.Tr "repo.see_on_door43"}}</span>
 							</a>
-							<a class="ui basic left pointing label" href="https://live.door43.org/u/{{.Owner.Name}}/{{.Name}}/">
+							<a class="ui basic left pointing label" href="https://door43.org/u/{{.Owner.Name}}/{{.Name}}/">
 								&#xfeff;<img id="door43-logo" src="/img/door43.png"/>
 							</a>
 						</div>


### PR DESCRIPTION
replace references in gogs from live.door43.org to door43.org

Issue-720
