### PR TITLE
About page

### DIFF
--- a/routers/routes/routes.go
+++ b/routers/routes/routes.go
@@ -25,6 +25,7 @@ import (
 	"code.gitea.io/gitea/routers/org"
 	"code.gitea.io/gitea/routers/private"
 	"code.gitea.io/gitea/routers/repo"
+	"code.gitea.io/gitea/routers/ufw"
 	"code.gitea.io/gitea/routers/user"
 
 	"github.com/go-macaron/binding"
@@ -696,6 +697,9 @@ func RegisterRoutes(m *macaron.Macaron) {
 		m.Get("", user.Notifications)
 		m.Post("/status", user.NotificationStatusPost)
 	}, reqSignIn)
+
+	// unfoldingWord (ufw) routes
+	m.Get("/about", ufw.About)
 
 	m.Group("/api", func() {
 		apiv1.RegisterRoutes(m)

--- a/routers/ufw/about.go
+++ b/routers/ufw/about.go
@@ -1,0 +1,18 @@
+package ufw
+
+import (
+	"code.gitea.io/gitea/modules/base"
+	"code.gitea.io/gitea/modules/context"
+)
+
+const (
+	// tplAbout about page template. This is the same as the home page that
+	// unauthenticated users see.
+	tplAbout base.TplName = "home"
+)
+
+// About render about page
+func About(ctx *context.Context) {
+	ctx.Data["PageIsHome"] = true
+	ctx.HTML(200, tplAbout)
+}

--- a/templates/base/head.tmpl
+++ b/templates/base/head.tmpl
@@ -146,7 +146,7 @@
 								{{else}}
 									<a class="item{{if .PageIsHome}} active{{end}}" href="{{AppSubUrl}}/">{{.i18n.Tr "home"}}</a>
 								{{end}}
-								<a class="item" href="{{AppSubUrl}}/Door43/pages/wiki/Welcome-to-Door43-Content-Service%21" rel="noreferrer">About DCS</a>
+								<a class="item" href="{{AppSubUrl}}/about" rel="noreferrer">About DCS</a>
 								<a class="item" href="http://ufw.io/team43" rel="noreferrer">{{.i18n.Tr "help"}}</a>
 
 								{{/*<div class="item">


### PR DESCRIPTION
#233. Adds an `/about` route that shows the home page, regardless of whether user is authenticated or not. I put the route handler in a unfoldingWord-specific directory to avoid future merge conflicts.