### PR TITLE
Fix footer

### DIFF
--- a/templates/base/footer.tmpl
+++ b/templates/base/footer.tmpl
@@ -7,7 +7,7 @@
 	<footer>
 		<div class="ui container">
 			<div class="ui left">
-				© {{ ThisYear }} DCS - <span class="license">Except where otherwise noted, content on DCS is licensed under a <bdi><a href="https://door43.org/en/copyright-and-licensing/" target="_blank">Creative Commons Attribution-ShareAlike 4.0 International License</a></bdi></span>
+				<span class="license">Except where otherwise noted, content on DCS is licensed under a <bdi><a href="https://door43.org/en/copyright-and-licensing/" target="_blank">CC BY-SA 4.0 License</a></bdi></span>
 			</div>
 			<div class="ui right links">
 				{{if (or .ShowFooterVersion .PageIsAdmin)}}{{.i18n.Tr "version"}}: {{AppVer}} {{.i18n.Tr "page"}}: <strong>{{LoadTimes .PageStartTime}}</strong> {{.i18n.Tr "template"}}: <strong>{{call .TmplLoadTimes}}</strong>{{end}}
@@ -24,7 +24,7 @@
 					</div>
 				</div>
 				<a href="{{AppSubUrl}}/vendor/librejs.html" data-jslicense="1">Javascript licenses</a>
-				<a href="{{AppSubUrl}}/api/swagger">API</a>
+				<a href="https://api-info.readthedocs.io/en/latest/">API</a>
 				<a target="_blank" rel="noopener" href="https://unfoldingword.org">unfoldingWord</a>
 				{{if (or .ShowFooterVersion .PageIsAdmin)}}<span class="version">{{GoVer}}</span>{{end}}
 			</div>


### PR DESCRIPTION
#236. Fix the API link, and make more space in the footer.

Two minor points:
1. I set the API link to https://api-info.readthedocs.io/en/latest/ instead of http://api-info.readthedocs.io/en/latest/; if there is a reason we need to use http instead of https, I can change it.
2. If we still need more room in the footer, maybe we can drop the link to the Javascript licenses.