### PR TITLE
Restore accidentally-removed Google Analytics JS

### DIFF
--- a/templates/base/footer.tmpl
+++ b/templates/base/footer.tmpl
@@ -67,5 +67,16 @@
 	<!-- JavaScript -->
 	<script src="{{AppSubUrl}}/vendor/plugins/semantic/semantic.min.js"></script>
 	<script src="{{AppSubUrl}}/js/index.js?v={{MD5 AppVer}}"></script>
+
+{{if GATrackingID}}
+<script>
+(function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+(i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+})(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
+ga('create', '{{GATrackingID}}', 'auto');
+ga('send', 'pageview');
+</script>
+{{end}}
 </body>
 </html>


### PR DESCRIPTION
Accidentally removed in a merge conflict, see https://github.com/unfoldingWord-dev/gogs/commit/4ab9ff4420d7269d5bcac5a6e1bbd84fd5b6af06#diff-c9b5a1b845abb8d0bcebdaf23d497b61