### PR TITLE
Add request info to error log messages

### DIFF
--- a/modules/context/context.go
+++ b/modules/context/context.go
@@ -95,7 +95,7 @@ func (ctx *Context) RenderWithErr(msg string, tpl base.TplName, form interface{}
 // Handle handles and logs error by given status.
 func (ctx *Context) Handle(status int, title string, err error) {
 	if err != nil {
-		log.Error(4, "%s: %v", title, err)
+		log.Error(4, "(%s %s) %s: %v", ctx.Req.Method, ctx.Req.URL.String(), title, err)
 		if macaron.Env != macaron.PROD {
 			ctx.Data["ErrorMsg"] = err
 		}


### PR DESCRIPTION
Will (hopefully) help in debugging/reproducing errors that occur in production.